### PR TITLE
Module standardized-audio-context was breaking old browsers

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -27,6 +27,9 @@ module.exports = {
 	configureWebpack: {
 		resolve: {
 			extensions: [".js", ".ts"],
+			alias: {
+				"standardized-audio-context": path.resolve('node_modules/standardized-audio-context/build/es5/bundle.js'),
+			}
 		},
 		output: {
 			pathinfo: false,


### PR DESCRIPTION
### Problem description
Module standardized-audio-context provides **ES5** and **ES2019**. While expected that Webpack could understand that it needs to use the ES5 version, it didn't happen.

### What was done
Provided alias into the **`vue.config.js`** file for this module. Now it uses the ES5 version instead.