### PR TITLE
Add peertube hint in chat video player

### DIFF
--- a/src/components/events/event/metaMessage/exported.css
+++ b/src/components/events/event/metaMessage/exported.css
@@ -11275,6 +11275,27 @@
   border-radius: 10px;
   overflow: hidden;
 }
+.pocketnet_iframe .share_common .peertube-server-hint {
+  z-index: 1;
+  position: absolute;
+  margin: 10px;
+  padding: 5px;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.7em;
+  background: #000000bb;
+  color: #fff;
+}
+.pocketnet_iframe .share_common .peertube-server-hint i.fa {
+  font-size: 0.8em;
+  margin-top: 1px;
+  margin-right: 5px;
+}
+.pocketnet_iframe .share_common .peertube-server-hint a {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
 .pocketnet_iframe .share_common .videoWrapper .videoTips {
   position: absolute;
   left: 0;

--- a/src/components/events/event/metaMessage/exported.less
+++ b/src/components/events/event/metaMessage/exported.less
@@ -7365,6 +7365,29 @@
     border-radius: 10px;
     overflow: hidden;
   }
+  .share_common .peertube-server-hint {
+    z-index: 1;
+    position: absolute;
+    margin: 10px;
+    padding: 5px;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 0.7em;
+    background: #000000bb;
+    color: #fff;
+
+    i.fa {
+      font-size: 0.8em;
+      margin-top: 1px;
+      margin-right: 5px;
+    }
+
+    a {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    }
+  }
   .share_common .videoWrapper .videoTips {
     position: absolute;
     left: 0;


### PR DESCRIPTION
### What was done
Adds support of peertube hint badge directly into the chat.

_Related to pocketnetteam/pocketnet.gui/pull/589_

<img src='https://user-images.githubusercontent.com/22795961/180952460-938cb623-d4a6-4279-94d3-30dd897d4648.png' width='200'>